### PR TITLE
Accept stores as object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,9 @@ var actionTypes = require('../actionTypes')
 // storeDefinition to be used to initialize a Nuclear.Store
 
 module.exports = {
-  name: 'counter',
+  getInitialState() {
+    return 0
+  },
   handlers: [
     {
       type: actionTypes.INCREMENT,
@@ -75,7 +77,7 @@ module.exports = {
 // counter/getters.js
 
 module.exports = {
-  count: ['counter']
+  count: ['count']
 }
 ```
 
@@ -91,9 +93,9 @@ the actions has `reactor` instance as their first argument.
 NuclearModule = require('nuclear-module')
 
 module.exports = NuclearModule({
-  stores: [
-    require('./stores/counter')
-  ],
+  stores: {
+    count: require('./stores/counter')
+  },
   actions: require('./actions'),
   getters: require('./getters')
 })

--- a/example/counter/getters.js
+++ b/example/counter/getters.js
@@ -1,4 +1,4 @@
 module.exports = {
-  count: ['counter']
+  count: ['count']
 }
 

--- a/example/counter/index.js
+++ b/example/counter/index.js
@@ -1,9 +1,9 @@
 var NuclearModule = require('../../index')
 
 module.exports = NuclearModule({
-  stores: [
-    require('./stores/counter')
-  ],
+  stores: {
+    count: require('./stores/counter')
+  },
   actions: require('./actions'),
   getters: require('./getters')
 })

--- a/example/counter/stores/counter.js
+++ b/example/counter/stores/counter.js
@@ -4,7 +4,9 @@ var actionTypes = require('../actionTypes')
 // storeDefinition to be used to initialize a Nuclear.Store
 
 module.exports = {
-  name: 'counter',
+  getInitialState() {
+    return 0
+  },
   handlers: [
     {
       type: actionTypes.INCREMENT,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuclear-module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An opiniated way of writing nuclear-js modules.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/NuclearModule.js
+++ b/src/NuclearModule.js
@@ -5,13 +5,8 @@ import isArray from 'lodash.isarray'
 import each from 'lodash.foreach'
 import reduce from 'lodash.reduce'
 
-export default function NuclearModule(options) {
-  let stores = options.stores || {}
-  let actions = options.actions || {}
-  let getters = options.getters || {}
-
-  return function(reactor, StoreFactory) {
-    StoreFactory = StoreFactory || Store
+export default function NuclearModule({ stores = {}, actions = {}, getters = {} }) {
+  return (reactor, StoreFactory = Store) => {
 
     let _stores = stores.reduce((acc, store) => {
       let storeName = store.name

--- a/src/NuclearModule.js
+++ b/src/NuclearModule.js
@@ -8,10 +8,7 @@ import reduce from 'lodash.reduce'
 export default function NuclearModule({ stores = {}, actions = {}, getters = {} }) {
   return (reactor, StoreFactory = Store) => {
 
-    let _stores = stores.reduce((acc, store) => {
-      let storeName = store.name
-      let storeDefinition = omit(store, 'name')
-
+    let _stores = reduce(stores, (acc, storeDefinition, storeName) => {
       if (reactor.evaluate([storeName])) {
         // TODO: Show a warning unless `debug/dev` mode.
         return

--- a/test/test.js
+++ b/test/test.js
@@ -9,10 +9,11 @@ describe('NuclearModule', function() {
   describe('#constructor', function() {
     it('registers nuclear stores to given reactor', function() {
       var CounterModule = NuclearModule({
-        stores: [{
-          name: 'counter',
-          getInitialState: () => 1
-        }]
+        stores: {
+          counter: {
+            getInitialState: () => 1
+          }
+        }
       })
 
       var reactor = new Nuclear.Reactor
@@ -27,10 +28,11 @@ describe('NuclearModule', function() {
       var expectedReactor = null
 
       var CounterModule = NuclearModule({
-        stores: [{
-          name: 'counter',
-          getInitialState: () => 1
-        }],
+        stores: {
+          counter: {
+            getInitialState: () => 1
+          }
+        },
         actions: {
           increment: function(reactor) {
             expectedReactor = reactor
@@ -48,14 +50,15 @@ describe('NuclearModule', function() {
 
     it('registers handlers from store definition', function() {
       var CounterModule = NuclearModule({
-        stores: [{
-          name: 'counter',
-          getInitialState() { return 1 },
-          handlers: [{
-            type: 'INCREMENT',
-            handler: (state) => state + 1
-          }]
-        }],
+        stores: {
+          count: {
+            getInitialState() { return 1 },
+            handlers: [{
+              type: 'INCREMENT',
+              handler: (state) => state + 1
+            }]
+          }
+        },
         actions: {
           increment: (reactor) => reactor.dispatch('INCREMENT')
         }
@@ -66,25 +69,26 @@ describe('NuclearModule', function() {
 
       counter.actions.increment()
 
-      expect(reactor.evaluate(['counter'])).toBe(2)
+      expect(reactor.evaluate(['count'])).toBe(2)
     })
 
     it('exports getters', function() {
 
       var CounterModule = NuclearModule({
-        stores: [{
-          name: 'counter',
-          getInitialState() { return 1 },
-          handlers: [{
-            type: 'INCREMENT',
-            handler: (state) => state + 1
-          }]
-        }],
+        stores: {
+          count: {
+            getInitialState() { return 1 },
+            handlers: [{
+              type: 'INCREMENT',
+              handler: (state) => state + 1
+            }]
+          }
+        },
         actions: {
           increment: (reactor) => reactor.dispatch('INCREMENT')
         },
         getters: {
-          count: ['counter']
+          count: ['count']
         }
       })
 


### PR DESCRIPTION
Updates module to accept stores as objects rather than arrays, depending on the feedback from @jordangarcia at the discussion optimizely/nuclear-js#201
